### PR TITLE
Fix error with changed_attributes in rails 4

### DIFF
--- a/lib/delegates_attributes_to.rb
+++ b/lib/delegates_attributes_to.rb
@@ -124,7 +124,7 @@ module DelegatesAttributesTo
           # If we don't skip it and have mutual delegation beetween 2 models
           # we get SystemStackError: stack level too deep while trying to load
           # a chain like user.profile.user.profile.user.profile...
-          next unless send("loaded_#{association}?")
+          next unless association(association).loaded?
           # skip if association object is nil
           next unless association_object = send(association)
           # call private method #changed_attributes

--- a/lib/delegates_attributes_to.rb
+++ b/lib/delegates_attributes_to.rb
@@ -135,8 +135,8 @@ module DelegatesAttributesTo
           result.merge! delegated_attribute => association_changed_attributes[attribute]
         end
         changed_attributes = super
-        changed_attributes.merge!(result)
-        changed_attributes
+        result.merge! changed_attributes
+        result
       end
   end
 end


### PR DESCRIPTION
Hey I think my change will stop this from raising an error in rails 4 about froozen hashs. Sorry I couldn't get the specs to run I think my rake or rspec version is too high (rake, version 10.4.2)
